### PR TITLE
Remove Delta healthcheck from docker compose file

### DIFF
--- a/tests/delta/docker-compose.yml
+++ b/tests/delta/docker-compose.yml
@@ -28,12 +28,6 @@ services:
         /opt/docker/bin/delta-app -Xmx4G
     ports:
       - 8080:8080
-    healthcheck:
-     test: ["CMD", "curl", "-f", "http://localhost:8080/v1/version"]
-     interval: 5s
-     retries: 5
-     start_period: 10s
-     timeout: 3s
     volumes:
       - ./config:/config
       - /tmp:/default-volume


### PR DESCRIPTION
Because curl is not provided by the base image anymore